### PR TITLE
Fixed pathing in Dockerfile backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /app
 # Create data directory
 # RUN mkdir -p /app/data
 
-COPY --from=builder /app/release/debug/backend .
+COPY --from=builder /app/target/release/backend .
 
 RUN chmod +x ./backend
 


### PR DESCRIPTION
# Pull Request

## Changes
- [x] Code changes
- [ ] Configuration changes 
- [ ] Documentation updates
- [x] Infrastructure changes

## Description
Fixed the Dockerfile pathing issue in the backend. make run-compose was failing due to incorrect missing copy paths and folder structures.

Related issue: #

## Quality Assurance
- [ ] Tests added/updated
- [ ] Documentation updated
- [X] Changes tested locally
- [ ] Security implications considered

## Deployment
- [ ] No breaking changes
- [ ] Database migrations required
- [ ] Environment variables added
- [X] Infrastructure dependencies updated

## Monitoring & Observability 
- [ ] Logging added/updated
- [ ] Metrics added/updated
- [ ] Alerts configured (if needed)

## Reviewers
- [ ] Code review completed
- [ ] Architecture review completed (if needed)
- [ ] Security review completed (if needed)

## Additional Notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the backend build process to use the optimized release version for production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->